### PR TITLE
Create initial version of setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,15 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='scibert',
+    version='0.1.0',
+    url='https://github.com/allenai/scibert.git',
+    author='Iz Beltagy',
+    description='A BERT model for scientific text.',
+    packages=find_packages(),
+    install_requires=[
+        'allennlp @ git+https://github.com/ibeltagy/allennlp@fp16_and_others',
+        'jsonlines',
+        'lxml'
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name='scibert',
     version='0.1.0',
     url='https://github.com/allenai/scibert.git',
-    author='Iz Beltagy',
+    author='AllenAI',
     description='A BERT model for scientific text.',
     packages=find_packages(),
     install_requires=[


### PR DESCRIPTION
### Goal
Make this repository installable
```
pip install git+https://github.com/allenai/scibert.git
```
Closes #83 

### Important notes
- The `@` syntax requires `pip>=19.1`
- Fixed the version to `0.1` ([semantic versioning](https://semver.org/))
- The `scripts`  and `data` folders are not included during installation. This means one could only use it for inference. To address this problem in the future I would suggest creating [entry_points](https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation) for the `scripts`. One could use [data_files](https://docs.python.org/3/distutils/setupscript.html#installing-additional-files)  for the `data` folder.
- I wanted to use the official `allennlp` branch since https://github.com/allenai/allennlp/pull/3537 introduced the gradient accumulation feature. However, the merged commit is only available in the new major releases (`1.x.x`) and it breaks the `scibert` code. Therefore I gave up and use the fork https://github.com/ibeltagy/allennlp@fp16_and_others instead (as done currently in `requirements.txt`)

